### PR TITLE
remove apt lists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   gcp-cli: circleci/gcp-cli@dev:alpha
-  orb-tools: circleci/orb-tools@8.27.0
+  orb-tools: circleci/orb-tools@8.27.1
 
 commands:
   install:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -8,6 +8,8 @@ steps:
           # Set sudo to work whether logged in as root user or non-root user
           if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 
+          $SUDO rm -rf /var/lib/apt/lists/*
+
           # Create an environment variable for the correct distribution
           if [[ $(command -v lsb_release) == "" ]]; then
             $SUDO apt-get update && \


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

https://github.com/CircleCI-Public/gcp-cli-orb/issues/9

> Because the image caches can be out of date, the first `sudo apt update` will fail on building a circleci job using an old image
([link](https://github.com/circleci/circleci-images/pull/378#issuecomment-504963660))

### Description

- remove apt lists
- also bump orb-tools
