### PR TITLE
Update default.yml

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -4,15 +4,15 @@ description: >
 parameters:
   python-version:
     type: string
-    default: "2.7"
+    default: "3.7"
     description: >
       What version of Python? For full options, see
       https://hub.docker.com/r/circleci/python/tags
 
   debian-release:
     type: enum
-    enum: ["stretch", "jessie"]
-    default: "stretch"
+    enum: ["buster", "stretch", "jessie"]
+    default: "buster"
     description: >
       Which Debian release?
 


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

Python 2.7 will reach its' EOL 01/01/2020: https://devguide.python.org/#status-of-python-branches.
Buster has been released recently: https://www.debian.org/releases/buster/index.en.html.

CircleCI Docker Hub includes these versions: https://hub.docker.com/r/circleci/python/tags?page=1&name=3.7-buster.

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

Use `Python 3.7` as default Python version.
Add `Buster` to Debian versions and use it as default one.

Happy Orbtoberfest!