### PR TITLE
Install from Versioned non-interactive CLI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,51 +1,37 @@
 version: 2.1
 
+install-initialize_requires-dev: &install-initialize_requires-dev
+  [install-default-dev, install-google-dev, install-machine-dev]
+
+install-initialize_requires-master: &install-initialize_requires-master
+  [install-default-master, install-google-master, install-machine-master]
+
+prod-deploy_requires: &prod-deploy_requires
+  [install_initialize-default-master, install_initialize-google-master, install_initialize-machine-master]
+
+
 orbs:
   gcp-cli: circleci/gcp-cli@dev:alpha
   orb-tools: circleci/orb-tools@8.27.1
-
-commands:
-  install:
-    steps:
-      - checkout
-
-      # test orb commands
-      - gcp-cli/install
-      - gcp-cli/initialize
 
 jobs:
   # default executor
   install-default:
     executor: gcp-cli/default
     steps:
-      - install
-
-  install-default-parameterized:
-    executor: gcp-cli/default
-    steps:
-      - install-parameterized
+      - gcp-cli/install
 
   # google cloud image
   install-google:
     executor: gcp-cli/google
     steps:
-      - install
-
-  install-google-parameterized:
-    executor: gcp-cli/google
-    steps:
-      - install-parameterized
+      - gcp-cli/install
 
   # machine executor
   install-machine:
     executor: gcp-cli/machine
     steps:
-      - install
-
-  install-machine-parameterized:
-    executor: gcp-cli/machine
-    steps:
-      - install-parameterized
+      - gcp-cli/install
 
 # yaml anchor filters
 integration-dev_filters: &integration-dev_filters
@@ -59,15 +45,6 @@ integration-master_filters: &integration-master_filters
     ignore: /.*/
   tags:
     only: /master-.*/
-
-install-initialize_requires-dev: &install-initialize_requires-dev
-  [install-default-dev, install-google-dev, install-machine-dev]
-
-install-initialize_requires-master: &install-initialize_requires-master
-  [install-default-master, install-google-master, install-machine-master]
-
-prod-deploy_requires: &prod-deploy_requires
-  [install_initialize-default-master, install_initialize-google-master, install_initialize-machine-master]
 
 install-post-steps: &install-post-steps
   [run: gcloud --version]

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -14,7 +14,7 @@ steps:
           # Set sudo to work whether logged in as root user or non-root user
           if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
           cd ~/
-          curl -s https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-<<parameters.version>>-linux-x86_64.tar.gz | tar xvz
+          curl -s https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-<<parameters.version>>-linux-x86_64.tar.gz | tar xz
           echo 'export PATH=~/google-cloud-sdk/path.bash.inc:$PATH' >> $BASH_ENV
           source $BASH_ENV
         }

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -15,7 +15,7 @@ steps:
           if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
           cd ~/
           curl -s https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-<<parameters.version>>-linux-x86_64.tar.gz | tar xz
-          echo 'export PATH=~/google-cloud-sdk/path.bash.inc:$PATH' >> $BASH_ENV
+          echo 'source ~/google-cloud-sdk/path.bash.inc' >> $BASH_ENV
           source $BASH_ENV
         }
 
@@ -32,6 +32,6 @@ steps:
           sudo rm -rf /opt/google-cloud-sdk
           install
         fi
-
-        echo "Success! gcloud has been installed; displaying version information:"
-        gcloud version
+  - run:
+      name: GCloud version
+      command: gcloud version

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,5 +1,11 @@
 description: Install the gcloud CLI, if not available
 
+parameters:
+  version:
+    type: string
+    default: "268.0.0"
+    description: "Version of the CLI to install. Must contain the full version number as it appears in the URL on this page: https://cloud.google.com/sdk/docs/downloads-versioned-archives"
+
 steps:
   - run:
       name: Install latest gcloud CLI version, if not available
@@ -7,33 +13,10 @@ steps:
         install () {
           # Set sudo to work whether logged in as root user or non-root user
           if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
-
-          $SUDO rm -rf /var/lib/apt/lists/*
-
-          # Create an environment variable for the correct distribution
-          if [[ $(command -v lsb_release) == "" ]]; then
-            $SUDO apt-get update && \
-              $SUDO apt-get -y install lsb-release
-
-            export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
-          else
-            export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
-          fi
-
-          # Add the Google Cloud SDK distribution URI as a package source
-          echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | $SUDO tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-
-          # Import the Google Cloud public key
-          if [[ $(command -v curl) == "" ]]; then
-            $SUDO apt-get update && \
-              $SUDO apt-get -y install curl
-          fi
-
-          curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | $SUDO apt-key add -
-
-          # Update and install the Cloud SDK
-          $SUDO apt-get update && \
-            $SUDO apt-get -y install google-cloud-sdk
+          cd ~/
+          curl -s https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-<<parameters.version>>-linux-x86_64.tar.gz | tar xvz
+          echo 'export PATH=~/google-cloud-sdk/path.bash.inc:$PATH' >> $BASH_ENV
+          source $BASH_ENV
         }
 
         if grep 'docker\|lxc' /proc/1/cgroup > /dev/null 2>&1; then

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -16,7 +16,6 @@ steps:
           cd ~/
           curl -s https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-<<parameters.version>>-linux-x86_64.tar.gz | tar xz
           echo 'source ~/google-cloud-sdk/path.bash.inc' >> $BASH_ENV
-          source $BASH_ENV
         }
 
         if grep 'docker\|lxc' /proc/1/cgroup > /dev/null 2>&1; then


### PR DESCRIPTION
This work was needed for progressing the Google Clour Run orb.

When attempting to use the command(s) `gcloud components install beta && gcloud components update` the following error is presented.

```
gcloud components install beta && gcloud components update
ERROR: (gcloud.components.install) 
You cannot perform this action because the Cloud SDK component manager 
is disabled for this installation. You can run the following command 
to achieve the same result for this installation: 

sudo apt-get install google-cloud-sdk
```

This appears to be a result of using the "interactive" CLI which is installed via `apt-get` which was called out in this Stack-Overflow: https://stackoverflow.com/questions/42697026/install-google-cloud-components-error-from-gcloud-command

Google recommends installing a versioned and "non-interactive" version of their CLI from this page: https://cloud.google.com/sdk/docs/downloads-versioned-archives


This change allows the user to enter in the version of the CLI for the Linux executor, or skip the installation on any non-docker executor as it did in the past. 

