### PR TITLE
[semver:patch] Add --retry and -S option

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -14,7 +14,7 @@ steps:
           # Set sudo to work whether logged in as root user or non-root user
           if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
           cd ~/
-          curl -s https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-<<parameters.version>>-linux-x86_64.tar.gz | tar xz
+          curl -Ss --retry 5 https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-<<parameters.version>>-linux-x86_64.tar.gz | tar xz
           echo 'source ~/google-cloud-sdk/path.bash.inc' >> $BASH_ENV
         }
 


### PR DESCRIPTION
### Checklist
- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
A customer said this curl command often failed to download files, so I added a retry option.
And also, -S option is to show error messages for the curl command.

I've confirmed, when the curl download file from `https://dl.google.com`, it fails one in ten times.
> https://app.circleci.com/pipelines/github/ganezasan/circleci-sandbox/3200/workflows/a54f5b29-4c28-41cc-811a-db6ebf461a55

And also, I compared with `wget` command, and it always successful because of the retry option. The default retry option in`wget` is 20.
> https://www.gnu.org/software/wget/manual/wget.html

After adding the retry option, I ran it 60 times and it all worked.
> https://app.circleci.com/pipelines/github/ganezasan/circleci-sandbox/3201/workflows/20a97484-801e-4957-aeed-416e733dd0d9
