### PR TITLE
V2 [semver:major]

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 description: |
-  Install and configure the Google Cloud CLI (gcloud)
+  Install and configure the Google Cloud CLI (gcloud CLI).
 
 display:
   home_url: https://cloud.google.com/sdk

--- a/src/commands/initialize.yml
+++ b/src/commands/initialize.yml
@@ -1,22 +1,22 @@
-description: Initilize the gcloud CLI
+description: "Initilize the gcloud CLI."
 
 parameters:
   gcloud-service-key:
     type: env_var_name
     default: GCLOUD_SERVICE_KEY
-    description: >
+    description: |
       Name of environment variable storing the full service key JSON file
-      for the Google project
+      for the Google project.
 
   google-project-id:
     type: env_var_name
     default: GOOGLE_PROJECT_ID
-    description: The Google project ID to connect with via the gcloud CLI
+    description: The Google project ID to connect with via the gcloud CLI.
 
   google-compute-zone:
     type: env_var_name
     default: GOOGLE_COMPUTE_ZONE
-    description: The Google compute zone to connect with via the gcloud CLI
+    description: The Google compute zone to connect with via the gcloud CLI.
 
 steps:
   - orb-tools/check-env-var-param:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,4 +1,8 @@
-description: Install the gcloud CLI, if not available
+description: |
+  Install the gcloud CLI. When installing within the Docker executor, the
+  install will only occur if the CLI isn't already installed. If installing in
+  a Linux machine image, it will remove the pre-installed version and instead
+  install the version specified by this orb.
 
 parameters:
   version:
@@ -32,5 +36,5 @@ steps:
           install
         fi
   - run:
-      name: GCloud version
+      name: "gcloud CLI version"
       command: gcloud version

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,20 +1,13 @@
-description: >
-  A debian based docker container to use when running the gcloud CLI
+description: The default executor is the CircleCI Python Convenience Image.
 
 parameters:
-  python-version:
+  version:
     type: string
-    default: "2.7"
-    description: >
-      What version of Python? For full options, see
-      https://hub.docker.com/r/circleci/python/tags
-
-  debian-release:
-    type: enum
-    enum: ["stretch", "jessie"]
-    default: "stretch"
-    description: >
-      Which Debian release?
+    default: "3.7"
+    description: |
+      Python version to use. Take into account the versions of Python available
+      from CircleCI (https://hub.docker.com/r/cimg/python/tags) as well as what
+      is supported by gcloud CLI itself (https://cloud.google.com/sdk/docs/install).
 
 docker:
-  - image: circleci/python:<<parameters.python-version>>-<<parameters.debian-release>>
+  - image: cimg/python:<<parameters.version>>

--- a/src/executors/google.yml
+++ b/src/executors/google.yml
@@ -1,5 +1,4 @@
-description: >
-  The official Google docker container with gcloud SDK pre-installed
+description: The official Google Docker image with gcloud SDK and CLI pre-installed.
 
 parameters:
   sdk-version:

--- a/src/executors/machine.yml
+++ b/src/executors/machine.yml
@@ -1,14 +1,14 @@
-description: >
+description: |
   CircleCI's machine executor:
   https://circleci.com/docs/2.0/executor-types/#using-machine
 
 parameters:
-  machine-image:
+  image:
     type: string
-    default: latest
-    description: >
-      What version of CircleCI's machine executor? For details, see
+    default: ubuntu-2004:202010-01
+    description: |
+      Which machine executor image to use. For details, see
       https://circleci.com/docs/2.0/configuration-reference/#machine
 
 machine:
-  image: circleci/classic:<<parameters.machine-image>>
+  image: <<parameters.image>>

--- a/src/jobs/install_and_initialize_cli.yml
+++ b/src/jobs/install_and_initialize_cli.yml
@@ -1,5 +1,4 @@
-description: >
-  Install gcloud CLI and initialize to connect to Google Cloud
+description: Install gcloud CLI and initialize to connect to Google Cloud.
 
 executor: <<parameters.executor>>
 


### PR DESCRIPTION
v2 update. Contains changes around copy and executors. See the related GitHub Milestone: https://github.com/CircleCI-Public/gcp-cli-orb/milestone/1