### PR TITLE
[semver:patch] Update the default `gcloud` version to 355.0.0

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -7,7 +7,7 @@ description: |
 parameters:
   version:
     type: string
-    default: "283.0.0"
+    default: "355.0.0"
     description: "Version of the CLI to install. Must contain the full version number as it appears in the URL on this page: https://cloud.google.com/sdk/docs/downloads-versioned-archives"
 
 steps:


### PR DESCRIPTION
### Checklist

- [X] All new jobs, commands, executors, parameters have descriptions
  - N/A: No new jobs/etc.
- [X] Examples have been added for any significant new features
  - N/A: No new features
- [X] README has been updated, if necessary
  - N/A: Unnecessary.

### Motivation, issues

The gcloud version being currently installed by default is already quite old ([283.0.0 -- 2020-03-03](https://cloud.google.com/sdk/docs/release-notes#28300_2020-03-03)) and an update is due.

Although it is possible to specify a version different than the default when invoking the `install` job, very often it is invoked as part of other higher level Orb, using the default value, like in [gcp-gcr/gcr-auth](https://circleci.com/developer/orbs/orb/circleci/gcp-gcr#commands-gcr-auth). Users of `gcp-gcr/gcr-auth` could still, and in addition, add a dependency to `gcp-cli` and invoke `gcp-cli/install` explicitly with a recent version. But that adds extra burden on the end user and feels a bit awkward to have two `install` jobs executed, with different versions, the first one actually performing the installation and the second one being just a no-op.

Therefore, I think it is valuable to try to keep the default version up to date, so that all users and access patterns are benefited and no workarounds are necessary for those not using `gcp-cli/install` directly that still want to have a not-too-old gcloud version.

### Description

Update the version of gcloud that is installed by default (i.e., when not explicitly provided as parameter) to the latest available version ([355.0.0 -- 2021-08-31](https://cloud.google.com/sdk/docs/release-notes#35500_2021-08-31) at the time of writing).
