### PR TITLE
[semver:patch] disable update check and usage reporting

### DIFF
--- a/src/commands/initialize.yml
+++ b/src/commands/initialize.yml
@@ -35,6 +35,8 @@ steps:
         echo $<<parameters.gcloud-service-key>> > ${HOME}/gcloud-service-key.json
 
         # Initialize gcloud CLI
+        gcloud --quiet config set core/disable_usage_reporting true
+        gcloud --quiet config set component_manager/disable_update_check true
         gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
         gcloud --quiet config set project $<<parameters.google-project-id>>
 


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
It's pretty typical to disable these features in Docker and CI, since they presumably are not that useful, and could also slow things down or add additional output.

I'm not sure if it needs to be done before `gcloud version` runs in the install step, but I think this should be Ok (it's out of date now, and `gcloud version` doesn't seem to report that).

### Description
set `core/disable_usage_reporting` and `component_manager/disable_update_check` in gcloud
