### PR TITLE
[semver:minor] make GOOGLE_COMPUTE_{REGION,ZONE} optional

### DIFF
--- a/src/commands/initialize.yml
+++ b/src/commands/initialize.yml
@@ -11,17 +11,23 @@ parameters:
   google-project-id:
     type: env_var_name
     default: GOOGLE_PROJECT_ID
-    description: The Google project ID to connect with via the gcloud CLI.
+    description: |
+      Name of environment variable storing the Google project ID to set as
+      default for the gcloud CLI.
 
   google-compute-zone:
     type: env_var_name
     default: GOOGLE_COMPUTE_ZONE
-    description: The Google compute zone to connect with via the gcloud CLI.
+    description: |
+      Name of environment variable storing the Google compute zone to set as
+      default for the gcloud CLI.
 
   google-compute-region:
-    description: The Google compute region to connect with via the gcloud CLI
     type: env_var_name
     default: GOOGLE_COMPUTE_REGION
+    description: |
+      Name of environment variable storing the Google compute region to set as
+      default for the gcloud CLI
 
 steps:
   - orb-tools/check-env-var-param:
@@ -40,9 +46,8 @@ steps:
 
         if [[ -n $<<parameters.google-compute-zone>> ]]; then
           gcloud --quiet config set compute/zone $<<parameters.google-compute-zone>>
-        elif [[ -n $<<parameters.google-compute-region>> ]]; then
+        fi
+
+        if [[ -n $<<parameters.google-compute-region>> ]]; then
           gcloud --quiet config set compute/region $<<parameters.google-compute-region>>
-        else
-          echo "ERROR: Set <<parameters.google-compute-zone>> or <<parameters.google-compute-region>> env variable" >&2
-          exit 1
         fi


### PR DESCRIPTION
## Checklist
- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
Fixes #38

The changes in #23 make the initialize command fail if one of `GOOGLE_COMPUTE_ZONE` or `GOOGLE_COMPUTE_REGION` is not set. While having one of these set implicitly may be useful for some people, it is not required for all commands, and can also usually be specified via `--zone`, `--region`, or `--location` explicitly as well. This also updates docs to make some parameter docs clearer.

### Description
Make initialize succeed even if neither of `GOOGLE_COMPUTE_ZONE` or `GOOGLE_COMPUTE_REGION` are set.
This will also enable _both_ to be set if both of the env vars exist.

Clarify docs:
- Clarify when it's the env var name vs. the value to use
- Clarify wording so it's clear that these are the _default_ values for the CLI to use
