### PR TITLE
[semver:minor] Update the default `gcloud` version to 363.0.0

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -7,7 +7,7 @@ description: |
 parameters:
   version:
     type: string
-    default: "283.0.0"
+    default: "363.0.0"
     description: "Version of the CLI to install. Must contain the full version number as it appears in the URL on this page: https://cloud.google.com/sdk/docs/downloads-versioned-archives"
 
 steps:


### PR DESCRIPTION
### Checklist
- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

### Description
Update gcloud CLI to 363.0.0

picked from #35 with original attribution to its author