### PR TITLE
fix: Bump default Google Cloud SDK to 383.0.0

### DIFF
--- a/src/jobs/install_and_initialize_cli.yml
+++ b/src/jobs/install_and_initialize_cli.yml
@@ -12,7 +12,7 @@ parameters:
 
   version:
     type: string
-    default: "283.0.0"
+    default: "383.0.0"
     description: "Version of the CLI to install. Must contain the full version number as it appears in the URL on this page: https://cloud.google.com/sdk/docs/downloads-versioned-archives"
 
   gcloud-service-key:


### PR DESCRIPTION
### Checklist

- **N/A** _All new jobs, commands, executors, parameters have descriptions_
- **N/A** _Examples have been added for any significant new features_
- **N/A** _README has been updated, if necessary_

### Motivation, issues
The current default for the Google Cloud SDK (283.0.0) is over 2 years old at this point and is no longer available to download. This updates the version to a current release (383.0.0) [[changelog](https://cloud.google.com/sdk/docs/release-notes)].

```
$ curl -i https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-283.0.0
HTTP/2 404 
content-length: 1449
content-type: text/html; charset=utf-8
server: downloads
x-content-type-options: nosniff
x-frame-options: SAMEORIGIN
x-xss-protection: 0
date: Tue, 03 May 2022 01:20:34 GMT
```

### Description
Bumps default Google Cloud SDK version to 383.0.0.
