### PR TITLE
feat: Added components parameter to install and setup commands

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -66,12 +66,20 @@ jobs:
           version: << parameters.version >>
       - run: *check-cli-version
 
+  install-components:
+    executor: gcp-cli/default
+    steps:
+      - checkout
+      - gcp-cli/setup:
+          components: kubectl package-go-module # smallest not install gcloud components
+
   auth-oidc:
     executor: gcp-cli/default
     steps:
       - checkout
       - gcp-cli/setup:
           use_oidc: true
+
 
 executors:
   alpine:
@@ -110,6 +118,8 @@ workflows:
           context:
             - gcp-cli-oidc
 
+      - install-components
+
       - orb-tools/pack:
           filters: *filters
 
@@ -121,6 +131,8 @@ workflows:
             - test-executor-versions
             - test-google-versions
             - test-alpine-versions
+            - install-components
+            - auth-oidc
             - orb-tools/pack
           context: orb-publisher
           filters:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -72,6 +72,7 @@ jobs:
       - checkout
       - gcp-cli/setup:
           components: kubectl package-go-module # smallest not install gcloud components
+      - run: gcloud components list | grep package-go-module || exit 1
 
   auth-oidc:
     executor: gcp-cli/default
@@ -79,7 +80,6 @@ jobs:
       - checkout
       - gcp-cli/setup:
           use_oidc: true
-
 
 executors:
   alpine:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -12,10 +12,17 @@ parameters:
       The version of the gcloud CLI to install.
       If left to "latest", the latest version will be installed.
       Otherwise, provide the full version number as it appears in the URL on this page: https://cloud.google.com/sdk/docs/downloads-versioned-archives"
+  components:
+    type: string
+    default: ""
+    description: >
+      The list of gcloud components to install. Space separated.
+      See https://cloud.google.com/sdk/docs/components for additional info.
 
 steps:
   - run:
       name: Install latest gcloud CLI version, if not available
       environment:
         ORB_VAL_VERSION: <<parameters.version>>
+        ORB_VAL_COMPONENTS: <<parameters.components>>
       command: << include(scripts/install.sh) >>

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -13,6 +13,13 @@ parameters:
       If left to "latest", the latest version will be installed.
       Otherwise, provide the full version number as it appears in the URL on this page: https://cloud.google.com/sdk/docs/downloads-versioned-archives
 
+  components:
+      type: string
+      default: ""
+      description: >
+        The list of gcloud components to install. Space separated.
+        See https://cloud.google.com/sdk/docs/components for additional info.
+
   gcloud_service_key:
     type: env_var_name
     default: GCLOUD_SERVICE_KEY
@@ -80,6 +87,7 @@ parameters:
 steps:
   - install:
       version: << parameters.version >>
+      components:
   - run:
       name: Initialize gcloud CLI to connect to Google Cloud
       environment:

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -87,7 +87,7 @@ parameters:
 steps:
   - install:
       version: << parameters.version >>
-      components:
+      components: << parameters.components >>
   - run:
       name: Initialize gcloud CLI to connect to Google Cloud
       environment:

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -93,7 +93,7 @@ if command -v gcloud > /dev/null 2>&1; then
     printf '%s\n' "The version installed ($installed_version) differs from the version requested ($version)."
     printf '%s\n' "Uninstalling v${installed_version}..."
     if ! uninstall; then printf '%s\n' "Failed to uninstall the current version."; exit 1; fi
-    
+
     printf '%s\n' "Installing v${version}..."
     if ! install "$version"; then printf '%s\n' "Failed to install the requested version."; exit 1; fi
   else
@@ -103,4 +103,15 @@ if command -v gcloud > /dev/null 2>&1; then
 else
   printf '%s\n' "Google Cloud SDK is not installed. Installing it."
   if ! install "$version"; then printf '%s\n' "Failed to install the requested version."; exit 1; fi
+fi
+
+# Install user provided gcloud components
+if [ -z "$ORB_VAL_COMPONENTS" ]; then
+  set -f
+  for component in $ORB_VAL_COMPONENTS; do
+      set -- "$@" "$component"
+  done
+  set +f
+
+  gcloud components install "$@"
 fi

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -106,7 +106,7 @@ else
 fi
 
 # Install user provided gcloud components
-if [ -z "$ORB_VAL_COMPONENTS" ]; then
+if [ -n "$ORB_VAL_COMPONENTS" ]; then
   set -f
   for component in $ORB_VAL_COMPONENTS; do
       set -- "$@" "$component"

--- a/src/scripts/setup.sh
+++ b/src/scripts/setup.sh
@@ -53,3 +53,5 @@ fi
 if [[ -n "$compute_region" ]]; then
   gcloud --quiet config set compute/region "$compute_region"
 fi
+
+echo "export ORB_GCP_CLI_SETUP=true" >> "$BASH_ENV"

--- a/src/scripts/setup.sh
+++ b/src/scripts/setup.sh
@@ -53,5 +53,3 @@ fi
 if [[ -n "$compute_region" ]]; then
   gcloud --quiet config set compute/region "$compute_region"
 fi
-
-echo "export ORB_GCP_CLI_SETUP=true" >> "$BASH_ENV"


### PR DESCRIPTION
### Motivation

Provide the user access to Install gcloud components between gcloud installation and initialization

### Description

Added optional `components` parameter to `setup` and `install` commands. Space separate component ids to install multiple. See https://cloud.google.com/sdk/docs/components for additional info.
 