### PR TITLE
fix: future proof installation url being changed

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -94,7 +94,7 @@ workflows:
             alias: test-executor-versions
             parameters:
               executor: [gcp-cli/default, gcp-cli/machine]
-              version: [latest, 371.0.0, 402.0.0]
+              version: [latest, 370.0.0, 410.0.0]
           context: orb-publisher
           filters: *filters
 
@@ -102,7 +102,7 @@ workflows:
           matrix:
             alias: test-alpine-versions
             parameters:
-              version: [latest, 371.0.0, 402.0.0]
+              version: [latest, 370.0.0, 410.0.0]
           context: orb-publisher
           filters: *filters
 
@@ -110,7 +110,7 @@ workflows:
           matrix:
             alias: test-google-versions
             parameters:
-              version: [latest, 371.0.0, 402.0.0]
+              version: [latest, 370.0.0, 410.0.0]
           context: orb-publisher
           filters: *filters
 

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -34,7 +34,7 @@ install() {
   cd "$base_dir" || return 1
 
   # after version 370, gcloud is called "cli" rather than "sdk"
-  major_version="$(echo "$1" | awk -F. '{print $1}')"
+  major_version="$(printf '%s\n' "$1" | awk -F. '{print $1}')"
   if [ "$major_version" -gt 370 ]; then
       url_path_fixture="cli"
   else

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -34,7 +34,7 @@ install() {
   cd "$base_dir" || return 1
 
   # after version 370, gcloud is called "cli" rather than "sdk"
-  major_version="$(printf '%s\n' "$1" | awk -F. '{print $1}')"
+  major_version="$(echo "$1" | awk -F. '{print $1}')"
   if [ "$major_version" -gt 370 ]; then
       url_path_fixture="cli"
   else

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -32,7 +32,16 @@ install() {
   [ -z "$arg_version" ] && printf '%s\n' "No version provided." && return 1
 
   cd "$base_dir" || return 1
-  curl --location --silent --fail --retry 3 https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-"$arg_version"-linux-x86_64.tar.gz | tar xz
+
+  # after version 370, gcloud is called "cli" rather than "sdk"
+  major_version="$(echo "$1" | awk -F. '{print $1}')"
+  if [ "$major_version" -gt 370 ]; then
+      url_path_fixture="cli"
+  else
+      url_path_fixture="sdk"
+  fi
+
+  curl --location --silent --fail --retry 3 "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-$url_path_fixture-$arg_version-linux-x86_64.tar.gz" | tar xz
   printf '%s\n' ". $base_dir/google-cloud-sdk/path.bash.inc" >> "$BASH_ENV"
 
   # If the envinronment is Alpine, remind the user to source $BASH_ENV in every step.


### PR DESCRIPTION
### Motivation, issues

The archived links https://cloud.google.com/sdk/docs/downloads-versioned-archives are now using `cli` instead of `sdk` after version 370

### Description

Added logic to resolve URL before installation