### PR TITLE
fix: version in example

### DIFF
--- a/src/examples/setup.yml
+++ b/src/examples/setup.yml
@@ -4,7 +4,7 @@ usage:
   version: 2.1
 
   orbs:
-    gcp-cli: circleci/gcp-cli@2.4.1
+    gcp-cli: circleci/gcp-cli@3.0.1
 
   jobs:
     use-gcp:


### PR DESCRIPTION
### Checklist

- [ ] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

I wanted to copy the example as is and try the orb. However, gcp-cli/setup step did not work as the version in the example is on v2.

### Description

I updated the example to v3 and it worked. 