### PR TITLE
Make project ID optional in setup script

### DIFF
--- a/src/scripts/setup.sh
+++ b/src/scripts/setup.sh
@@ -43,7 +43,9 @@ else
   gcloud auth activate-service-account --key-file="$HOME"/gcloud-service-key.json
 fi
 
-gcloud --quiet config set project "$project_id"
+if [[ -n "$project_id" ]]; then
+  gcloud --quiet config set project "$project_id"
+fi
 
 if [[ -n "$compute_zone" ]]; then
   gcloud --quiet config set compute/zone "$compute_zone"


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

When using OIDC to generate a WIF config file, this option makes no sense to require.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Only executes `gcloud config set project` in setup script if project ID env var is present.