### PR TITLE
feat: retry download when decompression fails

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -116,9 +116,11 @@ workflows:
 
       - auth-oidc:
           context:
-            - gcp-cli-oidc
+            - cpe-gcp
 
-      - install-components
+      - install-components:
+          context:
+            - cpe-gcp
 
       - orb-tools/pack:
           filters: *filters

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -89,19 +89,24 @@ download_and_extract() {
 }
 
 download_with_retry() {
+  local output_file="$1"
+  local url_path_fixture="$2"
+  local version="$3"
+  local install_directory="$4"
   local download_tries=0
-  local max_download_tries=2
+  local max_download_tries=3
 
-  while [ $download_tries -le $max_download_tries ]; do
-    if download_and_extract "$1" "$2" "$3" "$4"; then
+  while [ $download_tries -lt $max_download_tries ]; do
+    if download_and_extract "$output_file" "$url_path_fixture" "$version" "$install_directory"; then
       break
     else
       download_tries=$((download_tries + 1))
       printf "Download failed, retrying... (attempt: %d)\n" "$download_tries"
+      rm -rf "$install_directory"/*
     fi
   done
 
-  if [ $download_tries -gt $max_download_tries ]; then
+  if [ $download_tries -ge $max_download_tries ]; then
     printf "Failed to download and extract the tar file after %d attempts.\n" "$max_download_tries"
     return 1
   fi

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -102,7 +102,7 @@ download_with_retry() {
     else
       download_tries=$((download_tries + 1))
       printf "Download failed, retrying... (attempt: %d)\n" "$download_tries"
-      rm -rf "$install_directory"/*
+      rm -rf "${install_directory:?}"/*
     fi
   done
 

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -33,8 +33,7 @@ install() {
   if [ "$major_version" -gt 370 ]; then url_path_fixture="cli"
   else url_path_fixture="sdk"; fi
 
-  curl --location --silent --fail --retry 3 --output "$install_dir/google-cloud-sdk.tar.gz" "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-$url_path_fixture-$arg_version-linux-x86_64.tar.gz"
-  tar -xzf "$install_dir/google-cloud-sdk.tar.gz" -C "$install_dir"
+  download_with_retry "$install_dir/google-cloud-sdk.tar.gz" "$url_path_fixture" "$arg_version" "$install_dir" || exit 1
   printf '%s\n' ". $install_dir/google-cloud-sdk/path.bash.inc" >> "$BASH_ENV"
 
   # If the envinronment is Alpine, remind the user to source $BASH_ENV in every step.
@@ -75,6 +74,37 @@ uninstall() {
 
   # shellcheck disable=SC2086 # $sudo is not a variable, it's a command.
   $sudo rm -rf "$config_directory" || return 1
+}
+
+download_and_extract() {
+  local output_file="$1"
+  local url_path_fixture="$2"
+  local version="$3"
+  local install_directory="$4"
+
+  curl --location --silent --fail --retry 3 --output "$output_file" "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-$url_path_fixture-$version-linux-x86_64.tar.gz"
+  tar -xzf "$output_file" -C "$install_directory"
+
+  return $?
+}
+
+download_with_retry() {
+  local download_tries=0
+  local max_download_tries=2
+
+  while [ $download_tries -le $max_download_tries ]; do
+    if download_and_extract "$1" "$2" "$3" "$4"; then
+      break
+    else
+      download_tries=$((download_tries + 1))
+      printf "Download failed, retrying... (attempt: %d)\n" "$download_tries"
+    fi
+  done
+
+  if [ $download_tries -gt $max_download_tries ]; then
+    printf "Failed to download and extract the tar file after %d attempts.\n" "$max_download_tries"
+    return 1
+  fi
 }
 
 # Check if curl is installed


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

This PR closes #70 by addressing an issue where the Google Cloud SDK installation fails with an error related to a corrupt tar archive. This problem prevents users from successfully installing and using the Google Cloud SDK in their projects.

### Description

This PR modifies the installation script to introduce two new functions, `download_and_extract()` and `download_with_retry()`. These functions improve the process of downloading and extracting the Google Cloud SDK tar file by implementing retries when download failures occur.

The `download_and_extract()` function is responsible for downloading the tar file and extracting it to the specified installation directory. The `download_with_retry()` function wraps around the `download_and_extract()` function and retries the download process up to three times if a failure occurs.

These new functions are utilized in the installation script to improve the reliability of the installation process, reducing the chances of encountering the "unexpected end of file" error during Google Cloud SDK installation.

The updated script also includes additional error handling and messages to provide clearer feedback to the user in case of any issues during the installation process.