### PR TITLE
fix: skip installation if installed version is newer

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -127,12 +127,21 @@ if command -v gcloud > /dev/null 2>&1; then
   installed_version="$(gcloud version | head -n 1 | sed 's/Google Cloud SDK \([0-9]*.[0-9]*.[0-9]*\)/\1/')"
 
   if [ "$installed_version" != "$version" ]; then
-    printf '%s\n' "The version installed ($installed_version) differs from the version requested ($version)."
-    printf '%s\n' "Uninstalling v${installed_version}..."
-    if ! uninstall; then printf '%s\n' "Failed to uninstall the current version."; exit 1; fi
+    # Figure out which version is older between the installed version and the requested version.
+    older_version="$(printf '%s\n%s\n' "$installed_version" "$version" | sort -V | head -n 1)"
+    
+    # If the version requested is "latest" and the installed version is newer than the latest version available, skip installation.
+    if [ "$ORB_VAL_VERSION" = "latest" ] && [ "$older_version" = "$version" ]; then
+      printf '%s\n' "The version installed ($installed_version) is newer than the latest version listed in the release notes ($version)."
+      printf '%s\n' "Skipping installation."
+    else
+      printf '%s\n' "The version installed ($installed_version) differs from the version requested ($version)."
+      printf '%s\n' "Uninstalling v${installed_version}..."
+      if ! uninstall; then printf '%s\n' "Failed to uninstall the current version."; exit 1; fi
 
-    printf '%s\n' "Installing v${version}..."
-    if ! install "$version"; then printf '%s\n' "Failed to install the requested version."; exit 1; fi
+      printf '%s\n' "Installing v${version}..."
+      if ! install "$version"; then printf '%s\n' "Failed to install the requested version."; exit 1; fi
+    fi
   else
     printf '%s\n' "The version installed ($installed_version) matches the version requested ($version)."
     printf '%s\n' "Skipping installation."


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Closes #73 

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

This PR adds an extra check for the CLI installation. If the installed version is newer than whatever is retrieved from the release notes, we skip the installation.