### PR TITLE
Windows support

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -70,6 +70,7 @@ jobs:
     executor: gcp-cli/default
     steps:
       - checkout
+      - run: python --version
       - gcp-cli/setup:
           components: kubectl package-go-module # smallest not install gcloud components
       - run: gcloud components list | grep package-go-module || exit 1
@@ -78,13 +79,25 @@ jobs:
     executor: gcp-cli/default
     steps:
       - checkout
+      - run: python --version
       - gcp-cli/setup:
           use_oidc: true
 
 executors:
   alpine:
     docker:
-      - image: python:3.7-alpine
+      - image: python:3.8-alpine
+  windows-2019:
+    machine:
+      resource_class: windows.medium
+      image: windows-server-2019-vs2019:current
+  windows-2022:
+    machine:
+      resource_class: windows.medium
+      image: windows-server-2022-gui:current
+  ubuntu-2204-edge:
+    machine:
+      image: ubuntu-2204:edge
 
 workflows:
   test-deploy:
@@ -93,8 +106,8 @@ workflows:
           matrix:
             alias: test-executor-versions
             parameters:
-              executor: [gcp-cli/default, gcp-cli/machine]
-              version: [latest, 370.0.0, 410.0.0]
+              executor: [gcp-cli/default, gcp-cli/machine, ubuntu-2204-edge, windows-2019, windows-2022]
+              version: [latest, 456.0.0, 460.0.0]
           context: orb-publisher
           filters: *filters
 
@@ -110,7 +123,7 @@ workflows:
           matrix:
             alias: test-google-versions
             parameters:
-              version: [latest, 370.0.0, 410.0.0]
+              version: [latest, 456.0.0, 410.0.0]
           context: orb-publisher
           filters: *filters
 

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -3,7 +3,7 @@ description: The default executor is the CircleCI Python Convenience Image.
 parameters:
   version:
     type: string
-    default: "3.7"
+    default: "3.8"
     description: |
       Python version to use. Take into account the versions of Python available
       from CircleCI (https://hub.docker.com/r/cimg/python/tags) as well as what

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -54,14 +54,14 @@ install() {
 }
 
 uninstall() {
-  if ! command -v sudo > /dev/null 2>&1; then
+  if [ "${platform}" != "windows" ] && ! command -v sudo > /dev/null 2>&1; then
     printf '%s\n' "sudo is required to uninstall the Google Cloud SDK."
     printf '%s\n' "Please install it and try again."
     return 1
   fi
 
   # Set sudo to work whether logged in as root user or non-root user.
-  if [ "$(id -u)" -eq 0 ] || [ "${machine}" = "windows" ]; then sudo=""; else sudo="sudo"; fi
+  if [ "$(id -u)" -eq 0 ] || [ "${platform}" = "windows" ]; then sudo=""; else sudo="sudo"; fi
 
   local installation_directory
   installation_directory="$(gcloud info --format='value(installation.sdk_root)')"
@@ -121,18 +121,27 @@ fi
 
 unameOut="$(uname -s)"
 case "${unameOut}" in
-    Linux*)     machine=linux;;
-    Darwin*)    machine=mac;;
-    CYGWIN*)    machine=windows;;
-    MINGW*)     machine=windows;;
-    MSYS_NT*)   machine=windows;;
-    *)          machine="UNKNOWN:${unameOut}"
+    Linux*)     platform=linux;;
+    Darwin*)    platform=mac;;
+    CYGWIN*)    platform=windows;;
+    MINGW*)     platform=windows;;
+    MSYS_NT*)   platform=windows;;
+    *)          platform="UNKNOWN:${unameOut}"
 esac
 
-SORT="sort -V"
-if [ "${machine}" = "windows" ]; then
-  SORT="sort //R" # windows ships with a different sort utility
-fi
+printf "Detected platform: %s (%s)\n" "${platform}" "$(python --version)"
+
+sort_versions () {
+  local installed_version="$1"
+  local version="$2"
+
+  if [ "$platform" = "windows" ]; then
+    # this leans on the knowledge that node is bundled in the machine images
+    printf "%s %s" "$installed_version" "$version" | xargs npx semver | head -n 1
+  else
+    printf '%s\n%s\n' "$installed_version" "$version" | sort -V | head -n 1
+  fi
+}
 
 # Figure out what is latest version available if "latest" is passed as an argument.
 version="$ORB_VAL_VERSION"
@@ -143,8 +152,8 @@ if command -v gcloud > /dev/null 2>&1; then
 
   if [ "$installed_version" != "$version" ]; then
     # Figure out which version is older between the installed version and the requested version.
-    older_version="$(printf '%s\n%s\n' "$installed_version" "$version" | $SORT | head -n 1)"
-    
+    older_version="$(sort_versions "$installed_version" "$version")"
+
     # If the version requested is "latest" and the installed version is newer than the latest version available, skip installation.
     if [ "$ORB_VAL_VERSION" = "latest" ] && [ "$older_version" = "$version" ]; then
       printf '%s\n' "The version installed ($installed_version) is newer than the latest version listed in the release notes ($version)."


### PR DESCRIPTION
* Support Windows as a platform
* Modify the tested update versions to account for the inability of versions < `456.0.0` to work with Python >= 3.12

### Checklist
- [X] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues
Adds support to run the orb on Windows machine executors.

### Description
Remove the reliance on `sudo`, and support the built-in `sort` binary differences between *nix and WIndows