### PR TITLE
Add --quiet flag for installing gcloud components

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -183,5 +183,5 @@ if [ -n "$ORB_VAL_COMPONENTS" ]; then
   done
   set +f
 
-  gcloud components install "$@"
+  gcloud --quiet components install "$@"
 fi


### PR DESCRIPTION
When installing gcloud components, we are asked to input Y/n interactively and always fails by timeout on CI
I passed --quiet flag to solve this issue

<img width="1353" alt="スクリーンショット 2024-05-24 13 09 56" src="https://github.com/CircleCI-Public/gcp-cli-orb/assets/8651308/09b11923-3a65-42c2-9de3-1057ee7c04fe">
