### PR TITLE
chore: add --quiet flag for installing gcloud components

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -183,5 +183,5 @@ if [ -n "$ORB_VAL_COMPONENTS" ]; then
   done
   set +f
 
-  gcloud components install "$@"
+  gcloud --quiet components install "$@"
 fi


### PR DESCRIPTION
### Motivation, issues
Submitted in #84 by @tadashi0713 to prevent interactive prompt from stalling jobs until timeout.

### Description
Adds `--quiet` flag to `gcloud components install` command for unattended use cases.
