### PR TITLE
Feature/fix gcloud in path windows

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -154,7 +154,7 @@ workflows:
 
       - install-win:
           matrix:
-            alias: test-executor-versions
+            alias: test-win-executor-versions
             parameters:
               executor: [windows-2019, windows-2022]
               version: [latest, 456.0.0, 460.0.0]
@@ -194,6 +194,7 @@ workflows:
           pub-type: production
           requires:
             - test-executor-versions
+            - test-win-executor-versions
             - test-google-versions
             - test-alpine-versions
             - install-components

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -12,7 +12,8 @@ post-steps:
   - run: &check-cli-version
       name: "Check if the CLI was installed and the version is correct"
       command: |
-        exit 1
+        echo $PATH
+        which glcoud
         if [ << parameters.version >> = "latest" ]; then
           gcloud version || exit 1
         else

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -12,8 +12,8 @@ post-steps:
   - run: &check-cli-version
       name: "Check if the CLI was installed and the version is correct"
       command: |
-        echo $PATH
-        which glcoud
+        echo "PATH: $PATH"
+        which gcloud
         if [ << parameters.version >> = "latest" ]; then
           gcloud version || exit 1
         else

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -17,6 +17,7 @@ post-steps:
         else
           gcloud --version | grep -q "Google Cloud SDK << parameters.version >>" || exit 1
         fi
+
   - run: &check-cli-version-alpine
       name: "Check if the CLI was installed and the version is correct"
       command: |
@@ -26,6 +27,7 @@ post-steps:
         else
           gcloud --version | grep -q "Google Cloud SDK << parameters.version >>" || exit 1
         fi
+
   - run: &check-cli-version-bash
       name: "Check if the CLI was installed and the version is correct"
       shell: bash.exe
@@ -35,6 +37,7 @@ post-steps:
         else
           gcloud --version | grep -q "Google Cloud SDK << parameters.version >>" || exit 1
         fi
+
   - run: &check-cli-version-cmd
       name: "Check if the CLI was installed and the version is correct"
       shell: cmd.exe
@@ -44,6 +47,7 @@ post-steps:
         else
           gcloud --version | grep -q "Google Cloud SDK << parameters.version >>" || exit 1
         fi
+
   - run: &check-cli-version-powershell
       name: "Check if the CLI was installed and the version is correct"
       shell: powershell.exe

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -12,8 +12,6 @@ post-steps:
   - run: &check-cli-version
       name: "Check if the CLI was installed and the version is correct"
       command: |
-        echo "PATH: $PATH"
-        which gcloud
         if [ << parameters.version >> = "latest" ]; then
           gcloud version || exit 1
         else
@@ -23,6 +21,33 @@ post-steps:
       name: "Check if the CLI was installed and the version is correct"
       command: |
         . $BASH_ENV
+        if [ << parameters.version >> = "latest" ]; then
+          gcloud version || exit 1
+        else
+          gcloud --version | grep -q "Google Cloud SDK << parameters.version >>" || exit 1
+        fi
+  - run: &check-cli-version-bash
+      name: "Check if the CLI was installed and the version is correct"
+      shell: bash.exe
+      command: |
+        if [ << parameters.version >> = "latest" ]; then
+          gcloud version || exit 1
+        else
+          gcloud --version | grep -q "Google Cloud SDK << parameters.version >>" || exit 1
+        fi
+  - run: &check-cli-version-cmd
+      name: "Check if the CLI was installed and the version is correct"
+      shell: cmd.exe
+      command: |
+        if [ << parameters.version >> = "latest" ]; then
+          gcloud version || exit 1
+        else
+          gcloud --version | grep -q "Google Cloud SDK << parameters.version >>" || exit 1
+        fi
+  - run: &check-cli-version-powershell
+      name: "Check if the CLI was installed and the version is correct"
+      shell: powershell.exe
+      command: |
         if [ << parameters.version >> = "latest" ]; then
           gcloud version || exit 1
         else
@@ -41,6 +66,20 @@ jobs:
       - gcp-cli/install:
           version: <<parameters.version>>
       - run: *check-cli-version
+
+  install-win:
+    parameters:
+      executor:
+        type: executor
+      version:
+        type: string
+    executor: <<parameters.executor>>
+    steps:
+      - gcp-cli/install:
+          version: <<parameters.version>>
+      - run: *check-cli-version-bash
+      - run: *check-cli-version-cmd
+      - run: *check-cli-version-powershell
 
   install-alpine:
     parameters:
@@ -108,7 +147,16 @@ workflows:
           matrix:
             alias: test-executor-versions
             parameters:
-              executor: [gcp-cli/default, gcp-cli/machine, ubuntu-2204-edge, windows-2019, windows-2022]
+              executor: [gcp-cli/default, gcp-cli/machine, ubuntu-2204-edge]
+              version: [latest, 456.0.0, 460.0.0]
+          context: orb-publisher
+          filters: *filters
+
+      - install-win:
+          matrix:
+            alias: test-executor-versions
+            parameters:
+              executor: [windows-2019, windows-2022]
               version: [latest, 456.0.0, 460.0.0]
           context: orb-publisher
           filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -12,6 +12,7 @@ post-steps:
   - run: &check-cli-version
       name: "Check if the CLI was installed and the version is correct"
       command: |
+        exit 1
         if [ << parameters.version >> = "latest" ]; then
           gcloud version || exit 1
         else

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -42,13 +42,13 @@ post-steps:
       name: "Check if the CLI was installed and the version is correct"
       shell: cmd.exe
       command: |
-        gcloud version || EXIT 1
+        sh gcloud version
 
   - run: &check-cli-version-powershell
       name: "Check if the CLI was installed and the version is correct"
       shell: powershell.exe
       command: |
-        gcloud version || exit 1
+        sh gcloud version
 
 jobs:
   install:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -42,21 +42,13 @@ post-steps:
       name: "Check if the CLI was installed and the version is correct"
       shell: cmd.exe
       command: |
-        if [ << parameters.version >> = "latest" ]; then
-          gcloud version || exit 1
-        else
-          gcloud --version | grep -q "Google Cloud SDK << parameters.version >>" || exit 1
-        fi
+        gcloud version || EXIT 1
 
   - run: &check-cli-version-powershell
       name: "Check if the CLI was installed and the version is correct"
       shell: powershell.exe
       command: |
-        if [ << parameters.version >> = "latest" ]; then
-          gcloud version || exit 1
-        else
-          gcloud --version | grep -q "Google Cloud SDK << parameters.version >>" || exit 1
-        fi
+        gcloud version || exit 1
 
 jobs:
   install:

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -117,8 +117,8 @@ download_with_retry() {
 
 create_wrappers() {
   local download_directory="$1"
-  cat <<EOF > /c/Users/circleci/AppData/Local/Microsoft/WindowsApp/gcloud
-  bash -c "$download_directory/google-cloud-sdk/bin/gcloud"
+  cat <<EOF > /c/Users/circleci/AppData/Local/Microsoft/WindowsApps/gcloud
+  bash -c "$download_directory/google-cloud-sdk/bin/gcloud \$@"
 EOF
 }
 

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -118,6 +118,7 @@ download_with_retry() {
 create_wrappers() {
   local download_directory="$1"
   cat <<EOF > /c/Users/circleci/AppData/Local/Microsoft/WindowsApps/gcloud
+#! /usr/bin/bash
   bash -c "$download_directory/google-cloud-sdk/bin/gcloud \$@"
 EOF
 }

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -118,8 +118,7 @@ download_with_retry() {
 
 create_wrappers() {
   local download_directory="$1"
-  for COMMAND in $(ls "$download_directory"/google-cloud-sdk/bin); do
-  test -d "$download_directory"/google-cloud-sdk/bin/"$COMMAND" || continue
+  for COMMAND in {bootstrapping,docker-credential-gcloud,git-credential-gcloud.sh,bq,gcloud,gsutil}; do
   cat <<EOF > /c/Users/circleci/AppData/Local/Microsoft/WindowsApps/"$COMMAND"
 #!/usr/bin/bash
   bash -c "/c/Program Files/Google/google-cloud-sdk/bin/$COMMAND \$@"

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -34,6 +34,9 @@ install() {
   else url_path_fixture="sdk"; fi
 
   download_with_retry "$install_dir/google-cloud-sdk.tar.gz" "$url_path_fixture" "$arg_version" "$install_dir" || exit 1
+  if [ "$platform" = "windows" ]; then
+    copy_to_directory_in_path "$install_dir" # needed
+  fi
   printf '%s\n' ". $install_dir/google-cloud-sdk/path.bash.inc" >> "$BASH_ENV"
 
   # If the environment is Alpine, remind the user to source $BASH_ENV in every step.
@@ -110,6 +113,12 @@ download_with_retry() {
     printf "Failed to download and extract the tar file after %d attempts.\n" "$max_download_tries"
     return 1
   fi
+}
+
+copy_to_directory_in_path() {
+  local download_directory="$1"
+  cp -R "$download_directory/google-cloud-sdk/bin/*" /c/Users/circleci/AppData/Local/Microsoft/WindowsApps/
+  cp -R "$download_directory/google-cloud-sdk/lib" /c/Users/circleci/AppData/Local/Microsoft/WindowsApps/
 }
 
 # Check if curl is installed

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -117,9 +117,9 @@ download_with_retry() {
 
 create_wrappers() {
   local download_directory="$1"
-  cat <<EOF
+  cat <<EOF > /c/Users/circleci/AppData/Local/Microsoft/WindowsApp/gcloud
   bash -c "$download_directory/google-cloud-sdk/bin/gcloud"
-EOF  > /c/Users/circleci/AppData/Local/Microsoft/WindowsApp/gcloud
+EOF
 }
 
 # Check if curl is installed

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# shellcheck disable=SC3043 # while "local" isn't POSIX, it's supported in many shells. See: https://www.shellcheck.net/wiki/SC3043
+# shellcheck disable=SC3043,SC3009 # while "local" isn't POSIX, it's supported in many shells. See: https://www.shellcheck.net/wiki/SC3043
 
 fetch_latest_version() {
   local release_notes
@@ -117,7 +117,6 @@ download_with_retry() {
 }
 
 create_wrappers() {
-  local download_directory="$1"
   for COMMAND in {bootstrapping,docker-credential-gcloud,git-credential-gcloud.sh,bq,gcloud,gsutil}; do
   cat <<EOF > /c/Users/circleci/AppData/Local/Microsoft/WindowsApps/"$COMMAND"
 #!/usr/bin/bash

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -35,7 +35,7 @@ install() {
 
   download_with_retry "$install_dir/google-cloud-sdk.tar.gz" "$url_path_fixture" "$arg_version" "$install_dir" || exit 1
   if [ "$platform" = "windows" ]; then
-    copy_to_directory_in_path "$install_dir" # needed
+    create_wrappers "$install_dir"
   fi
   printf '%s\n' ". $install_dir/google-cloud-sdk/path.bash.inc" >> "$BASH_ENV"
 
@@ -115,10 +115,11 @@ download_with_retry() {
   fi
 }
 
-copy_to_directory_in_path() {
+create_wrappers() {
   local download_directory="$1"
-  cp -R "$download_directory/google-cloud-sdk/bin/*" /c/Users/circleci/AppData/Local/Microsoft/WindowsApps/
-  cp -R "$download_directory/google-cloud-sdk/lib" /c/Users/circleci/AppData/Local/Microsoft/WindowsApps/
+  cat <<EOF
+  bash -c "$download_directory/google-cloud-sdk/bin/gcloud"
+  EOF  > /c/Users/circleci/AppData/Local/Microsoft/WindowsApp/gcloud
 }
 
 # Check if curl is installed

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -119,7 +119,7 @@ create_wrappers() {
   local download_directory="$1"
   cat <<EOF
   bash -c "$download_directory/google-cloud-sdk/bin/gcloud"
-  EOF  > /c/Users/circleci/AppData/Local/Microsoft/WindowsApp/gcloud
+EOF  > /c/Users/circleci/AppData/Local/Microsoft/WindowsApp/gcloud
 }
 
 # Check if curl is installed

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -35,6 +35,7 @@ install() {
 
   download_with_retry "$install_dir/google-cloud-sdk.tar.gz" "$url_path_fixture" "$arg_version" "$install_dir" || exit 1
   if [ "$platform" = "windows" ]; then
+    cp -R "$install_dir/google-cloud-sdk" "/c/Program Files/Google/"
     create_wrappers "$install_dir"
   fi
   printf '%s\n' ". $install_dir/google-cloud-sdk/path.bash.inc" >> "$BASH_ENV"
@@ -117,10 +118,13 @@ download_with_retry() {
 
 create_wrappers() {
   local download_directory="$1"
-  cat <<EOF > /c/Users/circleci/AppData/Local/Microsoft/WindowsApps/gcloud
-#! /usr/bin/bash
-  bash -c "$download_directory/google-cloud-sdk/bin/gcloud \$@"
+  for COMMAND in $(ls "$download_directory"/google-cloud-sdk/bin); do
+  test -d "$download_directory"/google-cloud-sdk/bin/"$COMMAND" || continue
+  cat <<EOF > /c/Users/circleci/AppData/Local/Microsoft/WindowsApps/"$COMMAND"
+#!/usr/bin/bash
+  bash -c "/c/Program Files/Google/google-cloud-sdk/bin/$COMMAND \$@"
 EOF
+done
 }
 
 # Check if curl is installed

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# shellcheck disable=SC3043,SC3009 # while "local" isn't POSIX, it's supported in many shells. See: https://www.shellcheck.net/wiki/SC3043
+# shellcheck disable=SC3043 # while "local" isn't POSIX, it's supported in many shells. See: https://www.shellcheck.net/wiki/SC3043
 
 fetch_latest_version() {
   local release_notes
@@ -35,8 +35,8 @@ install() {
 
   download_with_retry "$install_dir/google-cloud-sdk.tar.gz" "$url_path_fixture" "$arg_version" "$install_dir" || exit 1
   if [ "$platform" = "windows" ]; then
-    cp -R "$install_dir/google-cloud-sdk" "/c/Program Files/Google/"
-    create_wrappers "$install_dir"
+    cp -R "$install_dir"/google-cloud-sdk/bin/* "/c/Users/circleci/AppData/Local/Microsoft/WindowsApps/"
+    cp -R "$install_dir"/google-cloud-sdk/lib "/c/Users/circleci/AppData/Local/Microsoft/WindowsApps/"
   fi
   printf '%s\n' ". $install_dir/google-cloud-sdk/path.bash.inc" >> "$BASH_ENV"
 
@@ -114,15 +114,6 @@ download_with_retry() {
     printf "Failed to download and extract the tar file after %d attempts.\n" "$max_download_tries"
     return 1
   fi
-}
-
-create_wrappers() {
-  for COMMAND in {bootstrapping,docker-credential-gcloud,git-credential-gcloud.sh,bq,gcloud,gsutil}; do
-  cat <<EOF > /c/Users/circleci/AppData/Local/Microsoft/WindowsApps/"$COMMAND"
-#!/usr/bin/bash
-  bash -c "/c/Program Files/Google/google-cloud-sdk/bin/$COMMAND \$@"
-EOF
-done
 }
 
 # Check if curl is installed

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -37,6 +37,7 @@ install() {
   if [ "$platform" = "windows" ]; then
     cp -R "$install_dir"/google-cloud-sdk/bin/* "/c/Users/circleci/AppData/Local/Microsoft/WindowsApps/"
     cp -R "$install_dir"/google-cloud-sdk/lib "/c/Users/circleci/AppData/Local/Microsoft/WindowsApps/"
+    cp -R "$install_dir"/google-cloud-sdk/platform "/c/Users/circleci/AppData/Local/Microsoft/WindowsApps/"
   fi
   printf '%s\n' ". $install_dir/google-cloud-sdk/path.bash.inc" >> "$BASH_ENV"
 


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
- https://cloud.google.com/sdk/gcloud/reference/auth/configure-docker was not working given that gcloud was not in the path

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
- this PR makes sure that gcloud gsutil and other gcp-cli tools are installed and available in windows PATH
- for this to work with cmd and powershell CLIs, the commands must be executed by bash: e.g. `bash gcloud version`
