### PR TITLE
feat(setup): make `GOOGLE_PROJECT_ID` envrionment variable optional

### DIFF
--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -33,6 +33,7 @@ parameters:
     description: |
       Name of environment variable storing the Google project ID to set as
       default for the gcloud CLI.
+      Setting this environment variable is optional.
 
   google_compute_zone:
     type: env_var_name

--- a/src/scripts/setup.sh
+++ b/src/scripts/setup.sh
@@ -43,7 +43,9 @@ else
   gcloud auth activate-service-account --key-file="$HOME"/gcloud-service-key.json
 fi
 
-gcloud --quiet config set project "$project_id"
+if [[ -n "$project_id" ]]; then
+  gcloud --quiet config set project "$project_id"
+fi
 
 if [[ -n "$compute_zone" ]]; then
   gcloud --quiet config set compute/zone "$compute_zone"


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

There are cases where setting `GOOGLE_PROJECT_ID` variable is not needed, for instance using OIDC. This PR makes `GOOGLE_PROJECT_ID` optional and conditionally runs `gcloud --quiet config set project "$project_id"` if and only if `GOOGLE_PROJECT_ID` is set.

### Description

- Make `GOOGLE_PROJECT_ID` envrionment variable optional