### PR TITLE
fix: Install correct gcloud CLI archive on Windows: (see PR #90)

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -266,7 +266,7 @@ workflows:
             alias: test-auth-oidc
             parameters:
               executor: [gcp-cli/machine, ubuntu-2204-edge, windows-2019, windows-2022]
-              version: [latest, 456.0.0, 460.0.0]
+              version: [latest, 460.0.0]
           context:
             - cpe-gcp
 
@@ -275,7 +275,7 @@ workflows:
             alias: test-auth-oidc-docker
             parameters:
               executor: [gcp-cli/machine, ubuntu-2204-edge]
-              version: [latest, 456.0.0, 460.0.0]
+              version: [latest, 460.0.0]
           context:
             - cpe-gcp
 
@@ -284,7 +284,7 @@ workflows:
       #      alias: test-auth-oidc-docker-win
       #      parameters:
       #        executor: [windows-2019, windows-2022]
-      #        version: [latest, 456.0.0, 460.0.0]
+      #        version: [latest, 460.0.0]
       #    context:
       #      - cpe-gcp
 
@@ -293,7 +293,7 @@ workflows:
             alias: test-install-components
             parameters:
               executor: [gcp-cli/default, gcp-cli/machine, ubuntu-2204-edge, windows-2019, windows-2022]
-              version: [latest, 456.0.0, 460.0.0]
+              version: [latest, 460.0.0]
           context:
             - cpe-gcp
 

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -232,7 +232,7 @@ workflows:
             alias: test-executor-versions
             parameters:
               executor: [gcp-cli/default, gcp-cli/machine, ubuntu-2204-edge]
-              version: [latest, 456.0.0, 460.0.0]
+              version: [latest, 460.0.0]
           context: orb-publisher
           filters: *filters
 
@@ -241,7 +241,7 @@ workflows:
             alias: test-win-executor-versions
             parameters:
               executor: [windows-2019, windows-2022]
-              version: [latest, 456.0.0, 460.0.0]
+              version: [latest, 460.0.0]
           context: orb-publisher
           filters: *filters
 
@@ -249,7 +249,7 @@ workflows:
           matrix:
             alias: test-alpine-versions
             parameters:
-              version: [latest, 370.0.0, 410.0.0]
+              version: [latest, 460.0.0]
           context: orb-publisher
           filters: *filters
 
@@ -257,7 +257,7 @@ workflows:
           matrix:
             alias: test-google-versions
             parameters:
-              version: [latest, 456.0.0, 410.0.0]
+              version: [latest, 460.0.0]
           context: orb-publisher
           filters: *filters
 


### PR DESCRIPTION
### Motivation, issues

From https://github.com/CircleCI-Public/gcp-cli-orb/pull/90

This orb incorrectly installs a Linux version of the gcloud CLI on Windows executors. This results in problems such as errors with subsequent docker builds and pushes to Google Artifact Registry.

Perhaps addresses https://github.com/CircleCI-Public/gcp-cli-orb/issues/81.

### Description

When running the install command on a Windows executor, download the gcloud CLI archive that was made for Windows.