### PR TITLE
Orb tries to install the latest CLI version, even though it's already in the image #80

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -158,6 +158,8 @@ jobs:
     parameters:
       version:
         type: string
+      executor:
+        type: executor
     executor: << parameters.executor >>
     steps:
       - run:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -185,6 +185,9 @@ jobs:
         type: string
       executor:
         type: executor
+      skip_installation:
+        type: boolean
+        default: true
     executor: << parameters.executor >>
     steps:
       - run:
@@ -192,7 +195,7 @@ jobs:
           command: apt-get install sudo -y
       - gcp-cli/install:
           version: << parameters.version >>
-          skip_installation: true
+          skip_installation: << parameters.skip_installation >>
       - run: *check-cli-version-skip-install
 
   install-components:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -12,7 +12,7 @@ post-steps:
   - run: &check-cli-version
       name: "Check if the CLI was installed and the version is correct"
       command: |
-        if [ << parameters.version >> = "latest" ]; then
+        if [ << parameters.version >> = "latest" ] || [ << parameters.skip_installation >> != 1 ]; then
           gcloud version || exit 1
         else
           gcloud --version

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -158,7 +158,7 @@ jobs:
     parameters:
       version:
         type: string
-    executor: "gcp-cli/google"
+    executor: << parameters.executor >>
     steps:
       - run:
           name: Install sudo
@@ -258,6 +258,9 @@ executors:
   macos-xcode-14-3-1:
     macos:
       xcode: 14.3.1
+  google-gcp-cli-451-0-0:
+    docker:
+      - image: google/cloud-sdk:451.0.0
 
 workflows:
   test-deploy:
@@ -310,7 +313,8 @@ workflows:
           matrix:
             alias: test-google-versions
             parameters:
-              version: [latest, 460.0.0]
+              version: [latest, 460.0.0, 451.0.1]
+              executor: [gcp-cli/google, google-gcp-cli-451-0-0]
           context: orb-publisher
           filters: *filters
 

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -336,7 +336,7 @@ workflows:
           context: orb-publisher
           filters: *filters
 
-      - install-google-skip-install
+      - install-google-skip-install:
           matrix:
             alias: test-google-versions-skip-install
             parameters:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -169,6 +169,22 @@ jobs:
           version: << parameters.version >>
       - run: *check-cli-version
 
+  install-google-skip-install:
+    parameters:
+      version:
+        type: string
+      executor:
+        type: executor
+    executor: << parameters.executor >>
+    steps:
+      - run:
+          name: Install sudo
+          command: apt-get install sudo -y
+      - gcp-cli/install:
+          version: << parameters.version >>
+          skip_installation: true
+      - run: *check-cli-version
+
   install-components:
     parameters:
       executor:
@@ -320,6 +336,15 @@ workflows:
           context: orb-publisher
           filters: *filters
 
+      - install-google-skip-install
+          matrix:
+            alias: test-google-versions-skip-install
+            parameters:
+              version: [latest, 460.0.0, 451.0.1]
+              executor: [gcp-cli/google, google-gcp-cli-451-0-0]
+          context: orb-publisher
+          filters: *filters
+
       - auth-oidc:
           matrix:
             alias: test-auth-oidc
@@ -367,6 +392,7 @@ workflows:
             - test-executor-versions
             - test-win-executor-versions
             - test-google-versions
+            - test-google-versions-skip-install
             - test-alpine-versions
             - test-macos-versions-400
             - test-macos-versions-500

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -9,10 +9,20 @@ filters: &filters
     only: /.*/
 
 post-steps:
-  - run: &check-cli-version
+  - run: &check-cli-version-skip-install
       name: "Check if the CLI was installed and the version is correct"
       command: |
         if [ << parameters.version >> = "latest" ] || [ << parameters.skip_installation >> != 1 ]; then
+          gcloud version || exit 1
+        else
+          gcloud --version
+          gcloud --version | grep -q "Google Cloud SDK << parameters.version >>" || exit 1
+        fi
+
+  - run: &check-cli-version
+      name: "Check if the CLI was installed and the version is correct"
+      command: |
+        if [ << parameters.version >> = "latest" ]; then
           gcloud version || exit 1
         else
           gcloud --version
@@ -183,7 +193,7 @@ jobs:
       - gcp-cli/install:
           version: << parameters.version >>
           skip_installation: true
-      - run: *check-cli-version
+      - run: *check-cli-version-skip-install
 
   install-components:
     parameters:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -18,6 +18,11 @@ parameters:
     description: >
       The list of gcloud components to install. Space separated.
       See https://cloud.google.com/sdk/docs/components for additional info.
+  skip_installation:
+    type: boolean
+    default: false
+    description: >
+      Useful flag to use when the executor already contains a valid gcloud installation.
 
 steps:
   - run:
@@ -25,4 +30,5 @@ steps:
       environment:
         ORB_VAL_VERSION: <<parameters.version>>
         ORB_VAL_COMPONENTS: <<parameters.components>>
+        ORB_VAL_SKIP_INSTALLATION: <<parameters.skip_installation>>
       command: << include(scripts/install.sh) >>

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -182,7 +182,7 @@ if command -v gcloud > /dev/null 2>&1; then
       printf '%s\n' "Skipping installation."
     fi
   else
-      printf '%s\n' "Found `gcloud` installed: ($installed_version)."
+      printf '%s\n' "Found gcloud installed: ($installed_version)."
       printf '%s\n' "Skipping installation."
   fi
 

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -159,26 +159,33 @@ version="$ORB_VAL_VERSION"
 if command -v gcloud > /dev/null 2>&1; then
   installed_version="$(gcloud version | head -n 1 | sed 's/Google Cloud SDK \([0-9]*.[0-9]*.[0-9]*\)/\1/')"
 
-  if [ "$installed_version" != "$version" ]; then
-    # Figure out which version is older between the installed version and the requested version.
-    older_version="$(sort_versions "$installed_version" "$version")"
+  if [ "$ORB_VAL_SKIP_INSTALLATION" != 1 ]; then
 
-    # If the version requested is "latest" and the installed version is newer than the latest version available, skip installation.
-    if [ "$ORB_VAL_VERSION" = "latest" ] && [ "$older_version" = "$version" ]; then
-      printf '%s\n' "The version installed ($installed_version) is newer than the latest version listed in the release notes ($version)."
-      printf '%s\n' "Skipping installation."
+    if [ "$installed_version" != "$version" ]; then
+      # Figure out which version is older between the installed version and the requested version.
+      older_version="$(sort_versions "$installed_version" "$version")"
+
+      # If the version requested is "latest" and the installed version is newer than the latest version available, skip installation.
+      if [ "$ORB_VAL_VERSION" = "latest" ] && [ "$older_version" = "$version" ]; then
+        printf '%s\n' "The version installed ($installed_version) is newer than the latest version listed in the release notes ($version)."
+        printf '%s\n' "Skipping installation."
+      else
+        printf '%s\n' "The version installed ($installed_version) differs from the version requested ($version)."
+        printf '%s\n' "Uninstalling v${installed_version}..."
+        if ! uninstall; then printf '%s\n' "Failed to uninstall the current version."; exit 1; fi
+
+        printf '%s\n' "Installing v${version}..."
+        if ! install "$version"; then printf '%s\n' "Failed to install the requested version."; exit 1; fi
+      fi
     else
-      printf '%s\n' "The version installed ($installed_version) differs from the version requested ($version)."
-      printf '%s\n' "Uninstalling v${installed_version}..."
-      if ! uninstall; then printf '%s\n' "Failed to uninstall the current version."; exit 1; fi
-
-      printf '%s\n' "Installing v${version}..."
-      if ! install "$version"; then printf '%s\n' "Failed to install the requested version."; exit 1; fi
+      printf '%s\n' "The version installed ($installed_version) matches the version requested ($version)."
+      printf '%s\n' "Skipping installation."
     fi
   else
-    printf '%s\n' "The version installed ($installed_version) matches the version requested ($version)."
-    printf '%s\n' "Skipping installation."
+      printf '%s\n' "Found `gcloud` installed: ($installed_version)."
+      printf '%s\n' "Skipping installation."
   fi
+
 else
   printf '%s\n' "Google Cloud SDK is not installed. Installing it."
   if ! install "$version"; then printf '%s\n' "Failed to install the requested version."; exit 1; fi


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
Currently this orb installs a gcloud binary and components.
In some scenarios users only want to install components and want to reuse the currently installed gcloud binary from the executor or docker image.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
This PR adds a new parameter to the `install` command called `skip_installation` which is a boolean that allows to skip installation of glcoud and only runs the installation of the specified gcloud components.