### PR TITLE
Skip OIDC and SA authenticatino if CLOUDSDK_AUTH_ACCESS_TOKEN is set

### DIFF
--- a/src/scripts/setup.sh
+++ b/src/scripts/setup.sh
@@ -16,31 +16,33 @@ printf '%s\n' "$service_key" > "$HOME"/gcloud-service-key.json
 gcloud --quiet config set core/disable_usage_reporting true
 gcloud --quiet config set component_manager/disable_update_check true
 
-# Use oidc
-if [ "$ORB_VAL_USE_OIDC" = 1 ]; then
-  echo "Authorizing using OIDC token"
+if [ -z "$CLOUDSDK_AUTH_ACCESS_TOKEN" ]; then # check issue/93
+  # Use oidc
+  if [ "$ORB_VAL_USE_OIDC" = 1 ]; then
+    echo "Authorizing using OIDC token"
 
-  if [ -z "$CIRCLE_OIDC_TOKEN" ]; then
-    echo "Ensure this job has a context to populate OIDC token"
-    echo "See more: https://circleci.com/docs/openid-connect-tokens/#openid-connect-id-token-availability"
-    exit 1
+    if [ -z "$CIRCLE_OIDC_TOKEN" ]; then
+      echo "Ensure this job has a context to populate OIDC token"
+      echo "See more: https://circleci.com/docs/openid-connect-tokens/#openid-connect-id-token-availability"
+      exit 1
+    fi
+
+    echo "$CIRCLE_OIDC_TOKEN" > "$HOME/oidc_token"
+    # Store OIDC token in temp file
+    gcloud iam workload-identity-pools create-cred-config \
+        "projects/${!ORB_ENV_PROJECT_NUMBER}/locations/global/workloadIdentityPools/${!ORB_ENV_POOL_ID}/providers/${!ORB_ENV_POOL_PROVIDER_ID}" \
+        --service-account="${!ORB_ENV_SERVICE_EMAIL}" \
+        --credential-source-type="text" \
+        --credential-source-file="$HOME/oidc_token" \
+        --output-file="$cred_file_path"
+
+    # Configure gcloud to leverage the generated credential configuration
+    gcloud auth login --brief --cred-file "$cred_file_path"
+    # Configure ADC
+    echo "export GOOGLE_APPLICATION_CREDENTIALS='$cred_file_path'" | tee -a "$BASH_ENV"
+  else
+    gcloud auth activate-service-account --key-file="$HOME"/gcloud-service-key.json
   fi
-
-  echo "$CIRCLE_OIDC_TOKEN" > "$HOME/oidc_token"
-  # Store OIDC token in temp file
-  gcloud iam workload-identity-pools create-cred-config \
-      "projects/${!ORB_ENV_PROJECT_NUMBER}/locations/global/workloadIdentityPools/${!ORB_ENV_POOL_ID}/providers/${!ORB_ENV_POOL_PROVIDER_ID}" \
-      --service-account="${!ORB_ENV_SERVICE_EMAIL}" \
-      --credential-source-type="text" \
-      --credential-source-file="$HOME/oidc_token" \
-      --output-file="$cred_file_path"
-
-  # Configure gcloud to leverage the generated credential configuration
-  gcloud auth login --brief --cred-file "$cred_file_path"
-  # Configure ADC
-  echo "export GOOGLE_APPLICATION_CREDENTIALS='$cred_file_path'" | tee -a "$BASH_ENV"
-else
-  gcloud auth activate-service-account --key-file="$HOME"/gcloud-service-key.json
 fi
 
 gcloud --quiet config set project "$project_id"


### PR DESCRIPTION
Add check of CLOUDSDK_AUTH_ACCESS_TOKEN to skip SA and OIDC given that the token is already provided

### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
See #93 

### Description
When the environment variable CLOUDSDK_AUTH_ACCESS_TOKEN is defined, there is no authentication needed.
The gcloud CLI will use the specified token. See: https://cloud.google.com/sdk/docs/authorizing