### PR TITLE
fix: Move install directory out of /tmp on Windows for stability

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -85,7 +85,7 @@ post-steps:
         cat \<<EOF > Dockerfile
         FROM alpine:edge
         ARG JOB_NUMBER
-        RUn echo $JOB_NUMBER > job_number
+        RUN echo $JOB_NUMBER > job_number
         RUN apk update
         RUN apk add curl
         CMD ["curl", "--version"]

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -26,7 +26,12 @@ install() {
   [ -z "$arg_version" ] && { printf '%s\n' "No version provided."; return 1; }
 
   local install_dir
-  install_dir="$(mktemp -d)"
+  if [ "${platform}" = "windows" ]; then
+    mkdir -p /opt
+    install_dir="$(mktemp -d -p /opt -t gcloud-cli.XXXXXXXXXX)"
+  else
+    install_dir="$(mktemp -d)"
+  fi
 
   # after version 370, gcloud is called "cli" rather than "sdk"
   major_version="$(echo "$1" | awk -F. '{print $1}')"


### PR DESCRIPTION

### Checklist

- [n/a] All new jobs, commands, executors, parameters have descriptions
- [n/a] Examples have been added for any significant new features
- [n/a] README has been updated, if necessary

### Motivation, issues

On Windows executors this orb installs the gcloud CLI files in /tmp. That directory gets cleaned out at unpredictable intervals that causes job failures when trying to run `gcloud` commands.

[issue](https://github.com/CircleCI-Public/gcp-cli-orb/issues/95)

### Description

move the gcloud CLI install directory out of /tmp on Windows to avoid unpredictable temp directory cleanup occurring mid-job

