### PR TITLE
bump default executor to python 3.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ workflows:
       - orb-tools/publish:
           orb-name: circleci/gcp-cli
           vcs-type: << pipeline.project.type >>
+          enable-pr-comment: false
           requires:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           context: orb-publisher

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -259,7 +259,7 @@ jobs:
 executors:
   alpine:
     docker:
-      - image: python:3.8-alpine
+      - image: python:3.13-alpine
   windows-2019:
     machine:
       resource_class: windows.medium

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -400,6 +400,7 @@ workflows:
       - orb-tools/publish:
           orb-name: circleci/gcp-cli
           vcs-type: << pipeline.project.type >>
+          enable-pr-comment: false
           pub-type: production
           requires:
             - test-executor-versions

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -326,7 +326,7 @@ workflows:
           matrix:
             alias: test-macos-versions-500
             parameters:
-              executor: [macos-xcode-16-2-0, macos-xcode-16-1-0, macos-xcode-16-0-0]
+              executor: [macos-xcode-16-2-0, macos-xcode-16-0-0]
               version: [500.0.0]
           context: orb-publisher
           filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -301,7 +301,7 @@ workflows:
             alias: test-executor-versions
             parameters:
               executor: [gcp-cli/default, gcp-cli/machine, ubuntu-2204-edge]
-              version: [latest, 460.0.0]
+              version: [latest, 500.0.0]
           context: orb-publisher
           filters: *filters
 
@@ -310,7 +310,7 @@ workflows:
             alias: test-win-executor-versions
             parameters:
               executor: [windows-2019, windows-2022]
-              version: [latest, 460.0.0]
+              version: [latest, 500.0.0]
           context: orb-publisher
           filters: *filters
 
@@ -318,7 +318,7 @@ workflows:
           matrix:
             alias: test-alpine-versions
             parameters:
-              version: [latest, 460.0.0]
+              version: [latest, 500.0.0]
           context: orb-publisher
           filters: *filters
 
@@ -336,7 +336,7 @@ workflows:
             alias: test-macos-versions-400
             parameters:
               executor: [macos-xcode-15-4-0, macos-xcode-15-3-0, macos-xcode-14-3-1]
-              version: [460.0.0]
+              version: [500.0.0]
           context: orb-publisher
           filters: *filters
 
@@ -344,7 +344,7 @@ workflows:
           matrix:
             alias: test-google-versions
             parameters:
-              version: [latest, 460.0.0, 451.0.1]
+              version: [latest, 500.0.0, 451.0.1]
               executor: [gcp-cli/google, google-gcp-cli-451-0-0]
           context: orb-publisher
           filters: *filters
@@ -353,7 +353,7 @@ workflows:
           matrix:
             alias: test-google-versions-skip-install
             parameters:
-              version: [latest, 460.0.0, 451.0.1]
+              version: [latest, 500.0.0, 451.0.1]
               executor: [gcp-cli/google, google-gcp-cli-451-0-0]
           context: orb-publisher
           filters: *filters
@@ -363,7 +363,7 @@ workflows:
             alias: test-auth-oidc
             parameters:
               executor: [gcp-cli/machine, ubuntu-2204-edge, windows-2019, windows-2022]
-              version: [latest, 460.0.0]
+              version: [latest, 500.0.0]
           context:
             - cpe-gcp
 
@@ -390,7 +390,7 @@ workflows:
             alias: test-install-components
             parameters:
               executor: [gcp-cli/default, gcp-cli/machine, ubuntu-2204-edge, windows-2019, windows-2022]
-              version: [latest, 460.0.0]
+              version: [latest, 500.0.0]
           context:
             - cpe-gcp
 

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -3,7 +3,7 @@ description: The default executor is the CircleCI Python Convenience Image.
 parameters:
   version:
     type: string
-    default: "3.8"
+    default: "3.13"
     description: |
       Python version to use. Take into account the versions of Python available
       from CircleCI (https://hub.docker.com/r/cimg/python/tags) as well as what


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Python 3.8 is at EOL.

### Description

* Bump default executor image from `python:3.8` to `python:3.13`.
* Disable PR comment on orb publish.

### Breaking changes

The default Python image tag for the default executor has been updated from `3.8` to `3.13`.

Who is affected: Jobs using the default executor without specifying a version parameter.

How to pin to a previous version:

Pass the version parameter to the executor in your `.circleci/config.yml`:

```yaml
executors:
  my-executor:
    executor:
      name: gcp-cli/default
      version: "3.12"
```
Or inline on a job:

```yaml
jobs:
  my-job:
    executor:
      name: gcp-cli/default
      version: "3.12"
    steps:
      - ...
```

The version value must be a valid tag from [cimg/python](https://hub.docker.com/r/cimg/python/tags) and supported by the [gcloud CLI](https://cloud.google.com/sdk/docs/install).