### PR TITLE
fix: resolve latest gcloud version from components-2.json

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -2,19 +2,15 @@
 # shellcheck disable=SC3043 # while "local" isn't POSIX, it's supported in many shells. See: https://www.shellcheck.net/wiki/SC3043
 
 fetch_latest_version() {
-  local release_notes
-  local release_notes_exit_code
+  local components_json
 
-  release_notes="$(curl --location --silent --fail --retry 3 https://cloud.google.com/sdk/docs/release-notes)"
-  release_notes_exit_code="$?"
-
-  [ "$release_notes_exit_code" -gt 0 ] && { printf '%s\n' "Failed to get release notes"; return "$release_notes_exit_code"; }
-
-  local releases
-  releases="$(printf '%s\n' "$release_notes" | grep -E '<h2 id=".*" data-text=".*">[0-9]+.[0-9]+.[0-9]+.*</h2>' | sed 's/<h2.*>\([0-9]*.[0-9]*.[0-9]*\).*<\/h2>/\1/')"
+  if ! components_json="$(curl --location --silent --fail --retry 3 https://dl.google.com/dl/cloudsdk/channels/rapid/components-2.json)"; then
+    printf '%s\n' "Failed to get latest version information"
+    return 1
+  fi
 
   local latest_version
-  latest_version="$(printf '%s\n' "$releases" | head -n 1)"
+  latest_version="$(printf '%s\n' "$components_json" | grep -oE '"version"[[:space:]]*:[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' | tail -n 1 | sed 's/.*"\([0-9]*\.[0-9]*\.[0-9]*\)"/\1/')" || true
 
   [ -z "$latest_version" ] && { printf '%s\n' "Couldn't find out what is the latest version available."; return 1; }
   version="$latest_version"
@@ -172,7 +168,7 @@ if command -v gcloud > /dev/null 2>&1; then
 
       # If the version requested is "latest" and the installed version is newer than the latest version available, skip installation.
       if [ "$ORB_VAL_VERSION" = "latest" ] && [ "$older_version" = "$version" ]; then
-        printf '%s\n' "The version installed ($installed_version) is newer than the latest version listed in the release notes ($version)."
+        printf '%s\n' "The version installed ($installed_version) is newer than the latest version available ($version)."
         printf '%s\n' "Skipping installation."
       else
         printf '%s\n' "The version installed ($installed_version) differs from the version requested ($version)."


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

`version: latest` intermittently fails with a bare `exit 1` and no diagnostics under CircleCI's default `bash -eo pipefail`. The script scraped `cloud.google.com` release-notes HTML; when the docs edge returned a 200 with unexpected content, `grep` failed and `set -e` killed the step before the script's own error handling could run.
 
Fixes #100 

### Description

- resolve `latest` from `https://dl.google.com/dl/cloudsdk/channels/rapid/components-2.json` (same CDN as the SDK tarballs) instead of scraping release-notes HTML
- make curl and parse failures reachable under `bash -eo pipefail` so the step prints an actionable message instead of a silent `exit 1`
- update the skip-install log line that still referred to "release notes"

Edge Case: if Google moves the version line elsewhere and introduces a similar one below it (that is not on the root object), it can fetch the wrong line. I would have used Python3 to parse JSON. However, it is possible to have a minimal image with `cURL` and no host `python3` install and run `gcloud` from the Linux tarball (which is bundled with python3). In that case, the Python3 strategy would fail.